### PR TITLE
Fix image RegExp being overly greedy

### DIFF
--- a/lib/ebook-writer/index.js
+++ b/lib/ebook-writer/index.js
@@ -86,7 +86,7 @@ function _writeChapters(that) {
     // ### replace the image source with the new local source
     var chapterContent = chapter.content;
     chapter.images.forEach( (image) => {
-      var re = new RegExp(`".*${image}"`, 'g');
+      var re = new RegExp(`"[^"]*${image}"`, 'g');
       let pathArray = image.split('/');
       var newLocation = image;
       if(pathArray.length > 1) {


### PR DESCRIPTION
The original regexp would match much more than just the file path, eg

`Hello "World" <img src="foo/image.jpg">`

Yield `"World" <img src="foo/image.jpg`