### PR TITLE
change baseurl to https://learning.oreilly.com

### DIFF
--- a/lib/safari/index.js
+++ b/lib/safari/index.js
@@ -16,7 +16,7 @@ const debug = require('debug')('safari'),
 const Safari = function Safari(debug) {
 
   // ## prepare base settings
-  this.baseUrl = "https://www.safaribooksonline.com";
+  this.baseUrl = "https://learning.oreilly.com";
   this.clientSecret = "f52b3e30b68c1820adb08609c799cb6da1c29975";
   this.clientId = "446a8a270214734f42a7";
   this.books = {};


### PR DESCRIPTION
change baseurl to https://learning.oreilly.com the old will cause redirect && auth will fail