### PR TITLE
Updated baseUrl to the latest.

### DIFF
--- a/lib/safari/index.js
+++ b/lib/safari/index.js
@@ -16,7 +16,12 @@ const debug = require('debug')('safari'),
 const Safari = function Safari(debug) {
 
   // ## prepare base settings
-  this.baseUrl = "https://www.safaribooksonline.com";
+  
+  // This url redirects to https://www.oreilly.com
+  // this.baseUrl = "https://www.safaribooksonline.com";
+  
+  // The latest url that works is https://learning.oreilly.com 
+  this.baseUrl = "https://learning.oreilly.com";
   this.clientSecret = "f52b3e30b68c1820adb08609c799cb6da1c29975";
   this.clientId = "446a8a270214734f42a7";
   this.books = {};


### PR DESCRIPTION
The baseUrl(https://www.safaribooksonline.com) used earlier redirects to  "https://www.oreilly.com", due to this books could not be downloaded. The lastest url is https://learning.oreilly.com, so the baseUrl has been updated to this.